### PR TITLE
Update Pacman setup command with 'yes' pipe.

### DIFF
--- a/setup
+++ b/setup
@@ -216,7 +216,7 @@ superbbootstrap_OpenBSD() {
 }
 
 superbbootstrap_Pacman() {
-	$PERMISSION_COMMAND pacman --sync --sysupgrade --refresh --noconfirm --needed
+	yes | LC_ALL=en_US.UTF-8 $PERMISSION_COMMAND pacman --sync --sysupgrade --refresh --needed
 }
 
 superbbootstrap_Portage() {


### PR DESCRIPTION
Changed Pacman update function because `--noconfirm` option doesn't assume 'always yes', but a rather a 'default option', which may be 'no'. It happens, for example, when you need to manually confirm deletion of old dependency, which is in conflict with a new package, otherwise the update process will be terminated.
More info: https://unix.stackexchange.com/a/293537
Error example: #16 